### PR TITLE
fix(renovate): remove invalid fields and add required match selector

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,124 +1,225 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices",
-    ":dependencyDashboard",
-    ":semanticCommits",
-    "helpers:pinGitHubActionDigests",
-    "docker:pinDigests"
-  ],
-  "python": {
-    "addManagePyEnvironment": true
-  },
-  "pip_requirements": {
-    "fileMatch": ["(^|/)requirements.*\\.txt$"]
-  },
-  "packageRules": [
-    {
-      "description": "Security-critical packages - immediate individual PRs (ADR-009)",
-      "matchPackagePatterns": [
-        "^cryptography", "^pyjwt", "^passlib", "^bcrypt", "^pyotp",
-        "^fastapi", "^uvicorn", "^gradio", "^pydantic", "^httpx",
-        "^azure-", "^anthropic", "^openai", "^qdrant-client"
-      ],
-      "matchUpdateTypes": ["patch", "minor", "major"],
-      "groupName": null,
-      "automerge": false,
-      "labels": ["security-critical", "automerge", "priority:high"],
-      "prPriority": 10,
-      "schedule": ["at any time"],
-      "minimumReleaseAge": "0 days"
-    },
-    {
-      "description": "CVE and vulnerability updates - immediate individual PRs (ADR-009)",
-      "vulnerabilityAlerts": true,
-      "osvVulnerabilityAlerts": true,
-      "groupName": null,
-      "automerge": false,
-      "labels": ["vulnerability", "automerge", "priority:critical"],
-      "prPriority": 15,
-      "schedule": ["at any time"],
-      "minimumReleaseAge": "0 days"
-    },
-    {
-      "description": "Monthly batch: routine dependency updates (ADR-009)",
-      "matchUpdateTypes": ["patch", "minor"],
-      "excludePackagePatterns": [
-        "^cryptography", "^pyjwt", "^passlib", "^bcrypt", "^pyotp",
-        "^fastapi", "^uvicorn", "^gradio", "^pydantic", "^httpx",
-        "^azure-", "^anthropic", "^openai", "^qdrant-client"
-      ],
-      "groupName": "routine-updates",
-      "automerge": false,
-      "labels": ["automerge", "batched-updates"],
-      "prPriority": 3,
-      "schedule": ["on the first day of the month"]
-    },
-    {
-      "description": "Major version updates always require manual review",
-      "matchUpdateTypes": ["major"],
-      "excludePackagePatterns": [
-        "^cryptography", "^pyjwt", "^passlib", "^bcrypt", "^pyotp",
-        "^fastapi", "^uvicorn", "^gradio", "^pydantic", "^httpx",
-        "^azure-", "^anthropic", "^openai", "^qdrant-client"
-      ],
-      "groupName": "major-updates",
-      "automerge": false,
-      "labels": ["requires-review", "scope:major"],
-      "reviewers": ["@williaby"],
-      "prPriority": 1,
-      "schedule": ["on the first day of the month"]
-    },
-    {
-      "description": "Development dependencies - monthly batch",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "dev-dependencies",
-      "automerge": false,
-      "labels": ["automerge", "dev-deps", "batched-updates"],
-      "prPriority": 2,
-      "schedule": ["on the first day of the month"]
-    },
-    {
-      "description": "GitHub Actions - pin to commit hashes with monthly updates",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["patch", "minor", "major"],
-      "groupName": "github-actions",
-      "automerge": false,
-      "labels": ["automerge", "github-actions"],
-      "prPriority": 4,
-      "schedule": ["on the first day of the month"],
-      "pinDigests": true
-    }
-  ],
-  "poetry": {
-    "enabled": true
-  },
-  "postUpdateOptions": [
-    "gomodTidy",
-    "npmDedupe",
-    "yarnDedupeHighest"
-  ],
-  "prConcurrentLimit": 3,
-  "prCreation": "immediate",
-  "rangeStrategy": "bump",
-  "semanticCommits": "enabled",
-  "timezone": "UTC",
-  "schedule": ["after 3am and before 5am every weekday", "every weekend"],
-  "vulnerabilityAlerts": {
-    "labels": ["security", "automerge"],
-    "assignees": ["@williaby"],
-    "prPriority": 10
-  },
-  "osvVulnerabilityAlerts": true,
-  "platformAutomerge": false,
-  "postUpgradeTasks": {
-    "commands": [
-      "poetry lock --no-update",
-      "chmod +x scripts/generate_requirements.sh",
-      "./scripts/generate_requirements.sh || echo 'Requirements generation failed'"
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:best-practices",
+        ":dependencyDashboard",
+        ":semanticCommits",
+        "helpers:pinGitHubActionDigests",
+        "docker:pinDigests"
     ],
-    "fileFilters": ["requirements*.txt", "poetry.lock"],
-    "executionMode": "update"
-  }
+    "pip_requirements": {
+        "fileMatch": [
+            "(^|/)requirements.*\\.txt$"
+        ]
+    },
+    "packageRules": [
+        {
+            "description": "Security-critical packages - immediate individual PRs (ADR-009)",
+            "matchPackagePatterns": [
+                "^cryptography",
+                "^pyjwt",
+                "^passlib",
+                "^bcrypt",
+                "^pyotp",
+                "^fastapi",
+                "^uvicorn",
+                "^gradio",
+                "^pydantic",
+                "^httpx",
+                "^azure-",
+                "^anthropic",
+                "^openai",
+                "^qdrant-client"
+            ],
+            "matchUpdateTypes": [
+                "patch",
+                "minor",
+                "major"
+            ],
+            "groupName": null,
+            "automerge": false,
+            "labels": [
+                "security-critical",
+                "automerge",
+                "priority:high"
+            ],
+            "prPriority": 10,
+            "schedule": [
+                "at any time"
+            ],
+            "minimumReleaseAge": "0 days"
+        },
+        {
+            "description": "CVE and vulnerability updates - immediate individual PRs (ADR-009)",
+            "vulnerabilityAlerts": true,
+            "osvVulnerabilityAlerts": true,
+            "groupName": null,
+            "automerge": false,
+            "labels": [
+                "vulnerability",
+                "automerge",
+                "priority:critical"
+            ],
+            "prPriority": 15,
+            "schedule": [
+                "at any time"
+            ],
+            "minimumReleaseAge": "0 days",
+            "matchJsonata": [
+                "isVulnerabilityAlert = true"
+            ]
+        },
+        {
+            "description": "Monthly batch: routine dependency updates (ADR-009)",
+            "matchUpdateTypes": [
+                "patch",
+                "minor"
+            ],
+            "excludePackagePatterns": [
+                "^cryptography",
+                "^pyjwt",
+                "^passlib",
+                "^bcrypt",
+                "^pyotp",
+                "^fastapi",
+                "^uvicorn",
+                "^gradio",
+                "^pydantic",
+                "^httpx",
+                "^azure-",
+                "^anthropic",
+                "^openai",
+                "^qdrant-client"
+            ],
+            "groupName": "routine-updates",
+            "automerge": false,
+            "labels": [
+                "automerge",
+                "batched-updates"
+            ],
+            "prPriority": 3,
+            "schedule": [
+                "on the first day of the month"
+            ]
+        },
+        {
+            "description": "Major version updates always require manual review",
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "excludePackagePatterns": [
+                "^cryptography",
+                "^pyjwt",
+                "^passlib",
+                "^bcrypt",
+                "^pyotp",
+                "^fastapi",
+                "^uvicorn",
+                "^gradio",
+                "^pydantic",
+                "^httpx",
+                "^azure-",
+                "^anthropic",
+                "^openai",
+                "^qdrant-client"
+            ],
+            "groupName": "major-updates",
+            "automerge": false,
+            "labels": [
+                "requires-review",
+                "scope:major"
+            ],
+            "reviewers": [
+                "@williaby"
+            ],
+            "prPriority": 1,
+            "schedule": [
+                "on the first day of the month"
+            ]
+        },
+        {
+            "description": "Development dependencies - monthly batch",
+            "matchDepTypes": [
+                "devDependencies"
+            ],
+            "matchUpdateTypes": [
+                "patch",
+                "minor"
+            ],
+            "groupName": "dev-dependencies",
+            "automerge": false,
+            "labels": [
+                "automerge",
+                "dev-deps",
+                "batched-updates"
+            ],
+            "prPriority": 2,
+            "schedule": [
+                "on the first day of the month"
+            ]
+        },
+        {
+            "description": "GitHub Actions - pin to commit hashes with monthly updates",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchUpdateTypes": [
+                "patch",
+                "minor",
+                "major"
+            ],
+            "groupName": "github-actions",
+            "automerge": false,
+            "labels": [
+                "automerge",
+                "github-actions"
+            ],
+            "prPriority": 4,
+            "schedule": [
+                "on the first day of the month"
+            ],
+            "pinDigests": true
+        }
+    ],
+    "poetry": {
+        "enabled": true
+    },
+    "postUpdateOptions": [
+        "gomodTidy",
+        "npmDedupe",
+        "yarnDedupeHighest"
+    ],
+    "prConcurrentLimit": 3,
+    "prCreation": "immediate",
+    "rangeStrategy": "bump",
+    "semanticCommits": "enabled",
+    "timezone": "UTC",
+    "schedule": [
+        "after 3am and before 5am every weekday",
+        "every weekend"
+    ],
+    "vulnerabilityAlerts": {
+        "labels": [
+            "security",
+            "automerge"
+        ],
+        "assignees": [
+            "@williaby"
+        ],
+        "prPriority": 10
+    },
+    "osvVulnerabilityAlerts": true,
+    "platformAutomerge": false,
+    "postUpgradeTasks": {
+        "commands": [
+            "poetry lock --no-update",
+            "chmod +x scripts/generate_requirements.sh",
+            "./scripts/generate_requirements.sh || echo 'Requirements generation failed'"
+        ],
+        "fileFilters": [
+            "requirements*.txt",
+            "poetry.lock"
+        ],
+        "executionMode": "update"
+    }
 }


### PR DESCRIPTION
## Summary

Two config-validation errors in `renovate.json` were preventing Renovate from processing this repo.

## Why

1. **`python.addManagePyEnvironment`** -- not a valid Renovate config field (removed from schema)
2. **`packageRules[2]`** (CVE vulnerability rule) -- had no `match*` or `exclude*` selector. Renovate requires every `packageRule` to include at least one selector. The rule intended to match vulnerability alerts but had no selector field.

## Changes

- `renovate.json`: removed `python.addManagePyEnvironment` (invalid field)
- `renovate.json`: added `matchJsonata: ["isVulnerabilityAlert = true"]` to the CVE rule (packageRules[2]) to provide the required match selector

## Impact

- Renovate will resume processing this repo normally
- CVE rule now correctly matches vulnerability alerts via `matchJsonata`

## Acceptance Criteria

- [ ] CI passes
- [ ] Next Renovate run shows `result=done` instead of `result=config-validation`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined configuration for automated dependency management and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->