### PR TITLE
fix(renovate): remove prPriority from vulnerabilityAlerts for v42 compat

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -207,8 +207,7 @@
         ],
         "assignees": [
             "@williaby"
-        ],
-        "prPriority": 10
+        ]
     },
     "osvVulnerabilityAlerts": true,
     "platformAutomerge": false,


### PR DESCRIPTION
## Summary

- Remove `"prPriority": 10` from the top-level `vulnerabilityAlerts` block in `renovate.json`.

## Why

Renovate v42.92.x (the homelab self-hosted version) rejects `prPriority` inside `vulnerabilityAlerts` — the field is only valid inside `packageRules` in v42. The v43+ schema relaxed this. Until the homelab Renovate stack upgrades to v43, this repo's config is producing a validator warning that, while not fatal, indicates schema drift.

The field is also redundant: an existing packageRule at lines 52-73 already prioritizes vulnerability-alert PRs via `matchJsonata: ["isVulnerabilityAlert = true"]` with `prPriority: 15`. Removing the top-level entry is purely subtractive.

## Validation

```
$ npx --package renovate@42.92.14 -- renovate-config-validator ./renovate.json
INFO: Validating ./renovate.json as global config
INFO: Config validated successfully
```

(Previously: `WARN: "prPriority" can't be used in "vulnerabilityAlerts". Allowed objects: packageRules.`)

## References

- Architecture reference: `docs/reference/renovate-architecture.md` § "Forbidden values" in the consumer repo
- Improvement plan: `docs/audits/dependency-management-improvement-plan-2026-05-24.md` § P0-3
- Will become a non-issue when homelab Renovate upgrades to v43 (separately tracked); this fix is forward-compatible.

## Test plan

- [ ] CI passes (no logic changes; renovate.json edit only)
- [ ] After merge: next Renovate scan against this repo produces no validator warning in the homelab logs
- [ ] Vulnerability-alert PRs continue to receive `prPriority: 15` from the existing packageRule

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected the vulnerability alerts configuration structure to ensure proper processing of security updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/williaby/PromptCraft/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->